### PR TITLE
Add separate workflows for alpha publish and daily releases

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -1,0 +1,20 @@
+name: Publish Alpha
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm publish --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -1,0 +1,17 @@
+name: Daily Release
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: daily-${{ github.run_id }}
+          name: Daily Release ${{ github.run_id }}
+          body: Automated daily release.


### PR DESCRIPTION
## Summary
- replace existing workflow with two workflows
- `alpha-publish.yml` publishes to npm on pushes to `main`
- `daily-release.yml` triggers automated daily releases

## Testing
- `npm test` *(fails: missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6864737b22e0832da8382303da44d0be