### PR TITLE
Fix publish workflow token step

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -15,6 +15,7 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
+      - run: npm config set _authToken=${{ secrets.NPM_PUBLISH_TOKEN }}
       - run: npm publish --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- update alpha publish workflow to explicitly set npm auth token before publishing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68647cbfa8b4832d922fb151163ed6b9