### PR TITLE
Fix npm auth in workflow

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - run: npm config set _authToken=${{ secrets.NPM_PUBLISH_TOKEN }}
+      - run: npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}
       - run: npm publish --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- fix `alpha-publish` GitHub action by using scoped auth token

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864955cc144832d9c31cd042ed18845