### PR TITLE
Pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -9,8 +9,8 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -8,9 +8,9 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           tag_name: daily-${{ github.run_id }}
           name: Daily Release ${{ github.run_id }}


### PR DESCRIPTION
## Summary
- pin checkout, setup-node and action-gh-release actions to specific commit hashes

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68647c3dbeac832d8d68bc9ff3cd34b5