### PR TITLE
Fix GitHub Actions push permissions

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   publish-npm:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   create-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744


### PR DESCRIPTION
## Summary
- ensure workflows can push commits and create releases by granting `contents: write` permission

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68649c3917c4832da991c90afb62481e