### PR TITLE
Publish default npm tag

### DIFF
--- a/.github/workflows/alpha-publish.yml
+++ b/.github/workflows/alpha-publish.yml
@@ -41,6 +41,6 @@ jobs:
           git push
 
       - run: npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_TOKEN }}
-      - run: npm publish --tag alpha
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- publish npm package with default tag by removing `--tag alpha`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68649e8674ac832da11af4e329ee27d7